### PR TITLE
ReliveThePast v1.2

### DIFF
--- a/ReliveThePast/EventHandlers.cs
+++ b/ReliveThePast/EventHandlers.cs
@@ -61,7 +61,7 @@ namespace ReliveThePast
 
         public void RevivePlayer(ReferenceHub rh)
         {
-            int num = randNum.Next(0, 8);
+            int num = randNum.Next(0, 7);
 
             switch (num)
             {
@@ -116,11 +116,9 @@ namespace ReliveThePast
                 case 7:
                     rh.characterClassManager.SetPlayersClass(RoleType.NtfCommander, rh.gameObject);
                     break;
-                case 8:
-                    rh.characterClassManager.SetPlayersClass(RoleType.Spectator, rh.gameObject);
-                    break;
             }
         }
     }
 }
+
 

--- a/ReliveThePast/EventHandlers.cs
+++ b/ReliveThePast/EventHandlers.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using EXILED;
 using EXILED.Extensions;
 using MEC;
@@ -11,13 +12,52 @@ namespace ReliveThePast
         float RespawnTimerValue = (float) Plugin.ReliveRespawnTimer;
         bool IsWarheadDetonated;
         bool IsDecontanimationActivated;
+        bool AllowRespawning = false;
 
         public void RunOnPlayerDeath(ref PlayerDeathEvent d)
         {
             ReferenceHub hub = d.Player;
             IsWarheadDetonated = Map.IsNukeDetonated;
             IsDecontanimationActivated = Map.IsLCZDecontaminated;
-            Timing.CallDelayed(RespawnTimerValue, () => RevivePlayer(hub));
+            if (AllowRespawning == true)
+                Timing.CallDelayed(RespawnTimerValue, () => RevivePlayer(hub));
+        }
+
+        public void RunOnCommand(ref RACommandEvent r)
+        {
+            try
+            {
+                string arg = r.Command;
+                ReferenceHub sender = r.Sender.SenderId == "SERVER CONSOLE" || r.Sender.SenderId == "GAME CONSOLE" ? PlayerManager.localPlayer.GetPlayer() : Player.GetPlayer(r.Sender.SenderId);
+
+                switch (arg.ToLower())
+                {
+                    case "allowautorespawn":
+                        r.Allow = false;
+                        if (!sender.CheckPermission("rtp.allow"))
+                        {
+                            r.Sender.RAMessage("You are not authorized to use this command");
+                            return;
+                        }
+                        if (AllowRespawning == false)
+                        {
+                            r.Sender.RAMessage("Auto respawning enabled!");
+                            Map.Broadcast("<color=green>Auto respawning enabled!</color>", 5);
+                            AllowRespawning = true;
+                        }
+                        else
+                        { 
+                            r.Sender.RAMessage("Auto respawning disabled!");
+                            Map.Broadcast("<color=red>Auto respawning disabled!</color>", 5);
+                            AllowRespawning = false;
+                        }
+                        break;
+                }
+            }
+            catch (Exception)
+            {
+                Log.Info("There was an error handling this command");
+            }
         }
 
         public void RevivePlayer(ReferenceHub rh)
@@ -84,3 +124,4 @@ namespace ReliveThePast
         }
     }
 }
+

--- a/ReliveThePast/EventHandlers.cs
+++ b/ReliveThePast/EventHandlers.cs
@@ -1,6 +1,7 @@
 using System;
 using EXILED;
 using EXILED.Extensions;
+using EXILED.Patches;
 using MEC;
 
 namespace ReliveThePast
@@ -20,6 +21,11 @@ namespace ReliveThePast
             IsDecontanimationActivated = Map.IsLCZDecontaminated;
             if (AllowRespawning == true)
                 Timing.CallDelayed(RespawnTimerValue, () => RevivePlayer(hub));
+        }
+
+        public void RunOnRoundRestart()
+        {
+            AllowRespawning = false;
         }
 
         public void RunOnCommand(ref RACommandEvent r)
@@ -120,5 +126,4 @@ namespace ReliveThePast
         }
     }
 }
-
 

--- a/ReliveThePast/EventHandlers.cs
+++ b/ReliveThePast/EventHandlers.cs
@@ -1,5 +1,4 @@
 using System;
-using System.IO;
 using EXILED;
 using EXILED.Extensions;
 using MEC;

--- a/ReliveThePast/Plugin.cs
+++ b/ReliveThePast/Plugin.cs
@@ -48,6 +48,7 @@ namespace ReliveThePast
         {
             Events.RemoteAdminCommandEvent -= Handler.RunOnCommand;
             Events.PlayerDeathEvent -= Handler.RunOnPlayerDeath;
+            Events.RoundRestartEvent -= Handler.RunOnRoundRestart;
             Handler = null;
         }
 
@@ -59,6 +60,7 @@ namespace ReliveThePast
 
             Log.Info("Starting up \"Re-live The Past - By DefyTheRush\"");
             Handler = new EventHandlers();
+            Events.RoundRestartEvent += Handler.RunOnRoundRestart;
             Events.PlayerDeathEvent += Handler.RunOnPlayerDeath;
             Events.RemoteAdminCommandEvent += Handler.RunOnCommand;
         }
@@ -69,3 +71,4 @@ namespace ReliveThePast
         }
     }
 }
+

--- a/ReliveThePast/Plugin.cs
+++ b/ReliveThePast/Plugin.cs
@@ -46,6 +46,7 @@ namespace ReliveThePast
 
         public override void OnDisable()
         {
+            Events.RemoteAdminCommandEvent -= Handler.RunOnCommand;
             Events.PlayerDeathEvent -= Handler.RunOnPlayerDeath;
             Handler = null;
         }
@@ -59,6 +60,7 @@ namespace ReliveThePast
             Log.Info("Starting up \"Re-live The Past - By DefyTheRush\"");
             Handler = new EventHandlers();
             Events.PlayerDeathEvent += Handler.RunOnPlayerDeath;
+            Events.RemoteAdminCommandEvent += Handler.RunOnCommand;
         }
 
         public override void OnReload()


### PR DESCRIPTION
Added:
- RA command for authorized roles to enable/disable the plugin in-game (allowautorespawn)
- Permission for authorized roles to use this command (rtp.allow)

Fixed:
- No need to spawn in as a spectator upon dying if auto-respawn is enabled (what was I thinking)
- Plugin disables automatically when the round restarts